### PR TITLE
Add input and affected registers to function table

### DIFF
--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -85,19 +85,19 @@ The 16 bit ABI generally follows the following conventions:
 
 | Label | Address | Class | Description | Inputs | Affects | Origin |
 |-|-|-|-|-|-|-|
-| [`ACPTR`](#function-name-acptr) | `$FFA5` | [CPB](#commodore-peripheral-bus "Commodore Peripheral Bus") | Read byte from peripheral bus | | | C64 |
-| `BASIN` | `$FFCF` | [ChIO](#channel-io "Channel I/O") | Get character | | | C64 |
-| `BSOUT` | `$FFD2` | ChIO | Write character | | | C64 |
-| `CIOUT` | `$FFA8` | CPB | Send byte to peripheral bus | | | C64 |  
-| `CLALL` | `$FFE7` | ChIO | Close all channels | | | C64 |
+| [`ACPTR`](#function-name-acptr) | `$FFA5` | [CPB](#commodore-peripheral-bus "Commodore Peripheral Bus") | Read byte from peripheral bus | | A X | C64 |
+| `BASIN` | `$FFCF` | [ChIO](#channel-io "Channel I/O") | Get character | | A X | C64 |
+| `BSOUT` | `$FFD2` | ChIO | Write character | A | C | C64 |
+| `CIOUT` | `$FFA8` | CPB | Send byte to peripheral bus | A | A X | C64 |  
+| `CLALL` | `$FFE7` | ChIO | Close all channels | | A X | C64 |
 | [`CLOSE`](#function-name-close) | `$FFC3` | ChIO | Close a channel | A | A X Y P | C64 |
-| `CHKIN` | `$FFC6` | ChIO | Set channel for character input | | | C64 |
+| `CHKIN` | `$FFC6` | ChIO | Set channel for character input | X | A X | C64 |
 | [`clock_get_date_time`](#function-name-clock_get_date_time) | `$FF50` | Time | Get the date and time | none | r0 r1 r2 r3L A X Y P | X16
 | [`clock_set_date_time`](#function-name-clock_set_date_time) | `$FF4D` | Time | Set the date and time | r0 r1 r2 r3L | A X Y P | X16
-| `CHRIN` | `$FFCF` | ChIO | Alias for `BASIN` | | | C64 |
-| `CHROUT` | `$FFD2` | ChIO | Alias for `BSOUT` | | | C64 |
-| `CLOSE_ALL` | `$FF4A` | ChIO | Close all files on a device  | | | C128 |
-| `CLRCHN` | `$FFCC` | ChIO | Restore character I/O to screen/keyboard | | | C64 |
+| `CHRIN` | `$FFCF` | ChIO | Alias for `BASIN` | | A X | C64 |
+| `CHROUT` | `$FFD2` | ChIO | Alias for `BSOUT` | A | C | C64 |
+| `CLOSE_ALL` | `$FF4A` | ChIO | Close all files on a device  | | A X | C128 |
+| `CLRCHN` | `$FFCC` | ChIO | Restore character I/O to screen/keyboard | | A X | C64 |
 | [`console_init`](#function-name-console_init) | `$FEDB` | Video | Initialize console mode | none | r0 A P | X16
 | [`console_get_char`](#function-name-console_get_char) | `$FEE1` | Video | Get character from console | A | r0 r1 r2 r3 r4 r5 r6 r12 r13 r14 r15 A X Y P | X16
 | [`console_put_char`](#function-name-console_put_char) | `$FEDE` | Video | Print character to console | A C | r0 r1 r2 r3 r4 r5 r6 r12 r13 r14 r15 A X Y P | X16
@@ -120,7 +120,7 @@ The 16 bit ABI generally follows the following conventions:
 | [`FB_set_palette`](#function-name-FB_set_palette) &#128683; | `$FEFC` | Video | Set (parts of) the palette | - | - | X16
 | [`FB_set_pixel`](#function-name-FB_set_pixel) | `$FF0B` | Video | Set one pixel, update cursor | A | none | X16
 | [`FB_set_pixels`](#function-name-FB_set_pixels) | `$FF0E` | Video | Copy pixels from RAM, update cursor | r0 r1 | A X P | X16
-| `GETIN` | `$FFE4` | Kbd | Get character from keyboard | | | C64 |
+| `GETIN` | `$FFE4` | Kbd | Get character from keyboard | | A X | C64 |
 | [`GRAPH_clear`](#function-name-GRAPH_clear) | `$FF23` | Video | Clear screen | none | r0 r1 r2 r3 A X Y P | X16
 | [`GRAPH_draw_image`](#function-name-GRAPH_draw_image) | `$FF38` | Video | Draw a rectangular image | r0 r1 r2 r3 r4 | A P | X16
 | [`GRAPH_draw_line`](#function-name-GRAPH_draw_line) | `$FF2C` | Video | Draw a line | r0 r1 r2 r3 | r0 r1 r2 r3 r7 r8 r9 r10 r12 r13 A X Y P | X16
@@ -135,7 +135,7 @@ The 16 bit ABI generally follows the following conventions:
 | [`GRAPH_set_window`](#function-name-GRAPH_set_window) &#8224;| `$FF26` | Video | Set clipping region | r0 r1 r2 r3 | A P | X16
 | [`i2c_read_byte`](#function-name-i2c_read_byte) | `$FEC6` | I2C | Read a byte from an I2C device | A X Y | A C | X16
 | [`i2c_write_byte`](#function-name-i2c_write_byte) | `$FEC9` | I2C | Write a byte to an I2C device | A X Y | A C | X16
-| `IOBASE` | `$FFF3` | Misc | Return start of I/O area | | | C64 |
+| `IOBASE` | `$FFF3` | Misc | Return start of I/O area | | X Y | C64 |
 | [`JSRFAR`](#function-name-JSRFAR) | `$FF6E` | Misc | Execute a routine on another RAM or ROM bank | PC+3 PC+5 | none | X16
 | [`joystick_get`](#function-name-joystick_get) | `$FF56` | Joy | Get one of the saved controller states | A | A X Y P | X16
 | [`joystick_scan`](#function-name-joystick_scan) | `$FF53` | Joy | Poll controller states and save them | none | A X Y P | X16
@@ -143,46 +143,46 @@ The 16 bit ABI generally follows the following conventions:
 | [`kbdbuf_peek`](#function-name-kbdbuf_peek) | `$FEBD` | Kbd | Get next char and keyboard queue length | A X | A X P | X16
 | [`kbdbuf_put`](#function-name-kbdbuf_put) | `$FEC3` | Kbd | Append a character to the keyboard queue | A | X | X16
 | [`keymap`](#function-name-keymap) | `$FED2` | Kbd | Set or get the current keyboard layout Call address | X Y C | A X Y C | X16
-| `LISTEN` | `$FFB1` | CPB | Send LISTEN command | | | C64 |
+| `LISTEN` | `$FFB1` | CPB | Send LISTEN command | A | A X | C64 |
 | `LKUPLA` | `$FF59` | ChIO | Search tables for given LA | | | C128 |
 | `LKUPSA` | `$FF5C` | ChIO | Search tables for given SA | | | C128 |
-| `LOAD` | `$FFD5` | ChIO | Load a file into memory | | | C64 |
+| `LOAD` | `$FFD5` | ChIO | Load a file into memory | A X Y | A X Y | C64 |
 | `MACPTR` | `$FF44` | CPB | Read multiple bytes from the peripheral bus | A X Y C | A X Y P | X16
 | `MEMBOT` | `$FF9C` | Mem | Get address of start of usable RAM | | | C64 |
 | [`memory_copy`](#function-name-memory_copy) | `$FEE7` | Mem | Copy a memory region to a different region | r0 r1 r2 | r2 A X Y P | X16
 | [`memory_crc`](#function-name-memory_crc) | `$FEEA` | Mem | Calculate the CRC16 of a memory region | r0 r1 | r2 A X Y P | X16
 | [`memory_decompress`](#function-name-memory_decompress) | `$FEED` | Mem | Decompress an LZSA2 block | r0 r1 | r1 A X Y P | X16
 | [`memory_fill`](#function-name-memory_fill) | `$FEE4` | Mem | Fill a memory region with a byte value | A r0 r1 | r1 X Y P | X16
-| `MEMTOP` | `$FF99` | Mem | Get address of end of usable RAM | | | C64 |
+| `MEMTOP` | `$FF99` | Mem | Get address of end of usable RAM | | A X Y | C64 |
 | [`monitor`](#function-name-monitor) | `$FF44` | Misc | Enter machine language monitor | none | A X Y P | X16
 | [`mouse_config`](#function-name-mouse_config) | `$FF68` | Mouse | Configure mouse pointer | A X Y | A X Y P | X16
 | [`mouse_get`](#function-name-mouse_get) | `$FF6B` | Mouse | Get saved mouse sate | X | A (X) P | X16
 | [`mouse_scan`](#function-name-mouse_scan) | `$FF71` | Mouse | Poll mouse state and save it | none | A X Y P | X16
-| `OPEN` | `$FFC0` | ChIO | Open a channel | | | C64 |
+| `OPEN` | `$FFC0` | ChIO | Open a channel | | A X Y | C64 |
 | `PFKEY` &#128683; | `$FF65` | Kbd | Program a function key *[not yet implemented]* | | | C128 |
-| `PLOT` | `$FFF0` | Video | Read/write cursor position | | | C64 |
+| `PLOT` | `$FFF0` | Video | Read/write cursor position | A X Y | A X Y | C64 |
 | `PRIMM` | `$FF7D` | Misc | Print string following the caller’s code | | | C128 |
-| `RDTIM` | `$FFDE` | Time | Read system clock | | | C64 |
-| `READST` | `$FFB7` | ChIO | Return status byte | | | C64 |
-| `SAVE` | `$FFD8` | ChIO | Save a file from memory | | | C64 |
-| `SCREEN` | `$FFED` | Video | Get the screen resolution  | | | C64 |
+| `RDTIM` | `$FFDE` | Time | Read system clock | | A X Y| C64 |
+| `READST` | `$FFB7` | ChIO | Return status byte | | A | C64 |
+| `SAVE` | `$FFD8` | ChIO | Save a file from memory | A X Y | A X Y | C64 |
+| `SCREEN` | `$FFED` | Video | Get the screen resolution  | | X Y | C64 |
 | [`screen_mode`](#function-name-screen_mode) | `$FF5F` | Video | Get/set screen mode | A C | A X Y P | X16
 | [`screen_set_charset`](#function-name-screen_set_charset) | `$FF62` | Video | Activate 8x8 text mode charset | A X Y | A X Y P | X16
-| `SECOND` | `$FF93` | CPB | Send LISTEN secondary address | | | C64 |
-| `SETLFS` | `$FFBA` | ChIO | Set LA, FA, and SA | | | C64 |
-| `SETMSG` | `$FF90` | ChIO | Set verbosity | | | C64 |
-| `SETNAM` | `$FFBD` | ChIO | Set filename | | | C64 |
-| `SETTIM` | `$FFDB` | Time | Write system clock | | | C64 |
+| `SECOND` | `$FF93` | CPB | Send LISTEN secondary address | A | A | C64 |
+| `SETLFS` | `$FFBA` | ChIO | Set LA, FA, and SA | A X Y | | C64 |
+| `SETMSG` | `$FF90` | ChIO | Set verbosity | A | | C64 |
+| `SETNAM` | `$FFBD` | ChIO | Set filename | A X Y | | C64 |
+| `SETTIM` | `$FFDB` | Time | Write system clock | A X Y | A X Y | C64 |
 | `SETTMO` | `$FFA2` | CPB | Set timeout | | | C64 |
 | [`sprite_set_image`](#function-name-sprite_set_image) &#8224; | `$FEF0` | Video | Set the image of a sprite | r0 r1 r2L A X Y C | A P | X16
 | [`sprite_set_position`](#function-name-sprite_set_position) | `$FEF3` | Video | Set the position of a sprite | r0 r1 A | A X P | X16
 | [`stash`](#function-name-stash) | `$FF77` | Mem | Write a byte to any RAM bank | stavec A X Y | (stavec) X P | X16
-| `STOP` | `$FFE1` | Kbd | Test for STOP key  | | | C64 |
-| `TALK` | `$FFB4` | CPB | Send TALK command  | | | C64 |
-| `TKSA` | `$FF96` | CPB | Send TALK secondary address | | | C64 |
-| `UDTIM` | `$FFEA` | Time | Increment the jiffies clock | | | C64 |
-| `UNLSN` | `$FFAE` | CPB | Send UNLISTEN command | | | C64 |
-| `UNTLK` | `$FFAB` | CPB | Send UNTALK command | | | C64 |
+| `STOP` | `$FFE1` | Kbd | Test for STOP key  | | A X P | C64 |
+| `TALK` | `$FFB4` | CPB | Send TALK command  | A | A | C64 |
+| `TKSA` | `$FF96` | CPB | Send TALK secondary address | A | A | C64 |
+| `UDTIM` | `$FFEA` | Time | Increment the jiffies clock | | A X | C64 |
+| `UNLSN` | `$FFAE` | CPB | Send UNLISTEN command | | A | C64 |
+| `UNTLK` | `$FFAB` | CPB | Send UNTALK command | | A | C64 |
 
 &#128683; = Currently unimplemented  
 &#8224; = Partially implemented  

--- a/X16 Reference - 04 - KERNAL.md
+++ b/X16 Reference - 04 - KERNAL.md
@@ -96,7 +96,7 @@ The 16 bit ABI generally follows the following conventions:
 | [`clock_set_date_time`](#function-name-clock_set_date_time) | `$FF4D` | Time | Set the date and time | r0 r1 r2 r3L | A X Y P | X16
 | `CHRIN` | `$FFCF` | ChIO | Alias for `BASIN` | | A X | C64 |
 | `CHROUT` | `$FFD2` | ChIO | Alias for `BSOUT` | A | C | C64 |
-| `CLOSE_ALL` | `$FF4A` | ChIO | Close all files on a device  | | A X | C128 |
+| `CLOSE_ALL` | `$FF4A` | ChIO | Close all files on a device  | | | C128 |
 | `CLRCHN` | `$FFCC` | ChIO | Restore character I/O to screen/keyboard | | A X | C64 |
 | [`console_init`](#function-name-console_init) | `$FEDB` | Video | Initialize console mode | none | r0 A P | X16
 | [`console_get_char`](#function-name-console_get_char) | `$FEE1` | Video | Get character from console | A | r0 r1 r2 r3 r4 r5 r6 r12 r13 r14 r15 A X Y P | X16


### PR DESCRIPTION
- Added information for the input and affected registers for C64-origin kernal routines.
- based on https://www.pagetable.com/c64ref/kernal/